### PR TITLE
Fix #1 Set get_active_deals() to fetch max number (1000) of deals in a call

### DIFF
--- a/bp_deal_manager.py
+++ b/bp_deal_manager.py
@@ -53,7 +53,8 @@ def get_active_deals():
         entity='deals',
         action='',
         payload={
-            "scope": "active"
+            "scope": "active",
+            "limit": "1000"
         }
     )
     if (error):


### PR DESCRIPTION
Fix rbrtio/BPDealManager#1

See https://github.com/3commas-io/3commas-official-api-docs/blob/master/deals_api.md
In a GET /ver1/deals call:
  -default value for limit is 50
  -max value for limit is 1000

Note that the case of more than 1000 active deals is not handled.
An improvement can be done using order and offset parameters and new calls when 1000 deals fetched happen.

Note that this fetches all deals from all bots.
An improvement can be done using account_id and bot_id parameters, so no need to check the name of the bot later.